### PR TITLE
Migrate to Clean Architecture 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:theme="@style/Theme.NovaDebug"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".presentation.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.NovaDebug">

--- a/app/src/main/java/com/example/novadebug/MainActivity.kt
+++ b/app/src/main/java/com/example/novadebug/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.navigation.compose.rememberNavController
 import com.example.novadebug.model.clinic.reservation.Reservation
 import com.example.novadebug.navigation.SetupNavGraph
-import com.example.novadebug.screens.reservations.ReservationScreen
+import com.example.novadebug.presentation.reservations.ReservationScreen
 import com.example.novadebug.presentation.ui.theme.NovaDebugTheme
 import com.example.novadebug.util.CLIENTS_COLLECTION
 import com.example.novadebug.util.CLIENT_NAME

--- a/app/src/main/java/com/example/novadebug/MainActivity.kt
+++ b/app/src/main/java/com/example/novadebug/MainActivity.kt
@@ -1,20 +1,11 @@
 package com.example.novadebug
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.navigation.compose.rememberNavController
-import com.example.novadebug.model.clinic.reservation.Reservation
 import com.example.novadebug.navigation.SetupNavGraph
-import com.example.novadebug.presentation.reservations.ReservationScreen
 import com.example.novadebug.presentation.ui.theme.NovaDebugTheme
-import com.example.novadebug.util.CLIENTS_COLLECTION
-import com.example.novadebug.util.CLIENT_NAME
-import com.example.novadebug.util.CLIENT_RESERVATIONS
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.firestore.ktx.toObject
-import com.google.firebase.ktx.Firebase
 import dagger.hilt.android.AndroidEntryPoint
 
 private const val TAG = "MainActivity"

--- a/app/src/main/java/com/example/novadebug/MainActivity.kt
+++ b/app/src/main/java/com/example/novadebug/MainActivity.kt
@@ -8,7 +8,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.novadebug.model.clinic.reservation.Reservation
 import com.example.novadebug.navigation.SetupNavGraph
 import com.example.novadebug.screens.reservations.ReservationScreen
-import com.example.novadebug.ui.theme.NovaDebugTheme
+import com.example.novadebug.presentation.ui.theme.NovaDebugTheme
 import com.example.novadebug.util.CLIENTS_COLLECTION
 import com.example.novadebug.util.CLIENT_NAME
 import com.example.novadebug.util.CLIENT_RESERVATIONS

--- a/app/src/main/java/com/example/novadebug/common/FirestoreConstants.kt
+++ b/app/src/main/java/com/example/novadebug/common/FirestoreConstants.kt
@@ -1,4 +1,4 @@
-package com.example.novadebug.util
+package com.example.novadebug.common
 
 const val CLIENTS_COLLECTION = "clients"
 const val CLIENT_NAME = "nova"

--- a/app/src/main/java/com/example/novadebug/common/NavigationConstants.kt
+++ b/app/src/main/java/com/example/novadebug/common/NavigationConstants.kt
@@ -1,3 +1,3 @@
-package com.example.novadebug.util
+package com.example.novadebug.common
 
 const val RESERVATIONS_SCREEN_ROUTE = "reservations_screen"

--- a/app/src/main/java/com/example/novadebug/common/components/ProgressBar.kt
+++ b/app/src/main/java/com/example/novadebug/common/components/ProgressBar.kt
@@ -1,0 +1,18 @@
+package com.example.novadebug.common.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ProgressBar() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}

--- a/app/src/main/java/com/example/novadebug/common/components/TopBar.kt
+++ b/app/src/main/java/com/example/novadebug/common/components/TopBar.kt
@@ -1,0 +1,19 @@
+package com.example.novadebug.common.components
+
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.example.novadebug.R
+
+@Composable
+fun TopBar() {
+    TopAppBar(
+        title =
+        {
+            Text(
+                text = stringResource(id = R.string.app_name)
+            )
+        }
+    )
+}

--- a/app/src/main/java/com/example/novadebug/data/repository/ClinicRepositoryImpl.kt
+++ b/app/src/main/java/com/example/novadebug/data/repository/ClinicRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.example.novadebug.data.repository
 
+import android.util.Log
 import com.example.novadebug.domain.model.clinic.reservation.Reservation
 import com.example.novadebug.domain.repository.ClinicRepository
 import com.example.novadebug.domain.repository.ReservationsResponse
@@ -12,6 +13,8 @@ import com.example.novadebug.domain.repository.AddReservationResponse
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.tasks.await
 
+private var TAG = ClinicRepositoryImpl::class.java.simpleName
+
 class ClinicRepositoryImpl @Inject constructor(
     private val reservationsRef: CollectionReference,
 ) : ClinicRepository {
@@ -22,6 +25,7 @@ class ClinicRepositoryImpl @Inject constructor(
                     val reservations = snapshot.toObjects(Reservation::class.java)
                     Success(reservations)
                 } else {
+                    Log.d(TAG, "Error ${error}")
                     Failure(error!!)
                 }
                 trySend(reservationsResponse)
@@ -35,7 +39,9 @@ class ClinicRepositoryImpl @Inject constructor(
     override suspend fun addReservation(reservation: Reservation): AddReservationResponse {
         return try {
             val id = reservationsRef.document().id
-            reservationsRef.document(id).set(reservation).await()
+            val resCopy = reservation.copy(id = id)
+            reservationsRef.document(id).set(resCopy).await()
+            Log.d(TAG, "Added Document Successfully with ID : ${id}")
             Success(true)
         } catch (e: Exception) {
             Failure(e)

--- a/app/src/main/java/com/example/novadebug/data/repository/ClinicRepositoryImpl.kt
+++ b/app/src/main/java/com/example/novadebug/data/repository/ClinicRepositoryImpl.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 import com.example.novadebug.domain.model.Response.*
+import com.example.novadebug.domain.repository.AddReservationResponse
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.tasks.await
 
 class ClinicRepositoryImpl @Inject constructor(
     private val reservationsRef: CollectionReference,
@@ -27,6 +29,16 @@ class ClinicRepositoryImpl @Inject constructor(
             awaitClose {
                 snapshotListener.remove()
             }
+        }
+    }
+
+    override suspend fun addReservation(reservation: Reservation): AddReservationResponse {
+        return try {
+            val id = reservationsRef.document().id
+            reservationsRef.document(id).set(reservation).await()
+            Success(true)
+        } catch (e: Exception) {
+            Failure(e)
         }
     }
 }

--- a/app/src/main/java/com/example/novadebug/data/repository/ClinicRepositoryImpl.kt
+++ b/app/src/main/java/com/example/novadebug/data/repository/ClinicRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.example.novadebug.data.repository
 
 import android.util.Log
-import com.example.novadebug.domain.model.clinic.reservation.Reservation
+import com.example.novadebug.domain.model.clinic.Reservation
 import com.example.novadebug.domain.repository.ClinicRepository
 import com.example.novadebug.domain.repository.ReservationsResponse
 import com.google.firebase.firestore.CollectionReference

--- a/app/src/main/java/com/example/novadebug/data/repository/ClinicRepositoryImpl.kt
+++ b/app/src/main/java/com/example/novadebug/data/repository/ClinicRepositoryImpl.kt
@@ -1,11 +1,32 @@
 package com.example.novadebug.data.repository
 
+import com.example.novadebug.domain.model.clinic.reservation.Reservation
 import com.example.novadebug.domain.repository.ClinicRepository
 import com.example.novadebug.domain.repository.ReservationsResponse
+import com.google.firebase.firestore.CollectionReference
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+import com.example.novadebug.domain.model.Response.*
+import kotlinx.coroutines.channels.awaitClose
 
-class ClinicRepositoryImpl : ClinicRepository {
+class ClinicRepositoryImpl @Inject constructor(
+    private val reservationsRef: CollectionReference,
+) : ClinicRepository {
     override fun getReservations(): Flow<ReservationsResponse> {
-        TODO("Not yet implemented")
+        return callbackFlow {
+            val snapshotListener = reservationsRef.addSnapshotListener { snapshot, error ->
+                val reservationsResponse = if (snapshot != null) {
+                    val reservations = snapshot.toObjects(Reservation::class.java)
+                    Success(reservations)
+                } else {
+                    Failure(error!!)
+                }
+                trySend(reservationsResponse)
+            }
+            awaitClose {
+                snapshotListener.remove()
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/novadebug/data/repository/ClinicRepositoryImpl.kt
+++ b/app/src/main/java/com/example/novadebug/data/repository/ClinicRepositoryImpl.kt
@@ -1,0 +1,11 @@
+package com.example.novadebug.data.repository
+
+import com.example.novadebug.domain.repository.ClinicRepository
+import com.example.novadebug.domain.repository.ReservationsResponse
+import kotlinx.coroutines.flow.Flow
+
+class ClinicRepositoryImpl : ClinicRepository {
+    override fun getReservations(): Flow<ReservationsResponse> {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/example/novadebug/di/AppModule.kt
+++ b/app/src/main/java/com/example/novadebug/di/AppModule.kt
@@ -5,6 +5,7 @@ import com.example.novadebug.common.CLIENT_NAME
 import com.example.novadebug.common.CLIENT_RESERVATIONS
 import com.example.novadebug.data.repository.ClinicRepositoryImpl
 import com.example.novadebug.domain.repository.ClinicRepository
+import com.example.novadebug.domain.use_case.AddReservation
 import com.example.novadebug.domain.use_case.GetReservations
 import com.example.novadebug.domain.use_case.UseCases
 import com.google.firebase.firestore.CollectionReference
@@ -36,6 +37,7 @@ object AppModule {
     fun provideUseCases(
         repo: ClinicRepository,
     ) = UseCases(
-        getReservations = GetReservations(repo)
+        getReservations = GetReservations(repo),
+        addReservation = AddReservation(repo)
     )
 }

--- a/app/src/main/java/com/example/novadebug/di/AppModule.kt
+++ b/app/src/main/java/com/example/novadebug/di/AppModule.kt
@@ -1,0 +1,24 @@
+package com.example.novadebug.di
+
+import com.example.novadebug.common.CLIENTS_COLLECTION
+import com.example.novadebug.common.CLIENT_NAME
+import com.example.novadebug.common.CLIENT_RESERVATIONS
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+    @Provides
+    fun provideFirebaseFirestore() = Firebase.firestore
+
+    @Provides
+    fun provideReservationsRef(
+        db: FirebaseFirestore,
+    ) = db.collection(CLIENTS_COLLECTION).document(CLIENT_NAME).collection(CLIENT_RESERVATIONS)
+}

--- a/app/src/main/java/com/example/novadebug/di/AppModule.kt
+++ b/app/src/main/java/com/example/novadebug/di/AppModule.kt
@@ -3,6 +3,9 @@ package com.example.novadebug.di
 import com.example.novadebug.common.CLIENTS_COLLECTION
 import com.example.novadebug.common.CLIENT_NAME
 import com.example.novadebug.common.CLIENT_RESERVATIONS
+import com.example.novadebug.data.repository.ClinicRepositoryImpl
+import com.example.novadebug.domain.repository.ClinicRepository
+import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
@@ -21,4 +24,9 @@ object AppModule {
     fun provideReservationsRef(
         db: FirebaseFirestore,
     ) = db.collection(CLIENTS_COLLECTION).document(CLIENT_NAME).collection(CLIENT_RESERVATIONS)
+
+    @Provides
+    fun provideClinicRepository(
+        reservationsRef: CollectionReference,
+    ): ClinicRepository = ClinicRepositoryImpl(reservationsRef)
 }

--- a/app/src/main/java/com/example/novadebug/di/AppModule.kt
+++ b/app/src/main/java/com/example/novadebug/di/AppModule.kt
@@ -5,6 +5,8 @@ import com.example.novadebug.common.CLIENT_NAME
 import com.example.novadebug.common.CLIENT_RESERVATIONS
 import com.example.novadebug.data.repository.ClinicRepositoryImpl
 import com.example.novadebug.domain.repository.ClinicRepository
+import com.example.novadebug.domain.use_case.GetReservations
+import com.example.novadebug.domain.use_case.UseCases
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
@@ -29,4 +31,11 @@ object AppModule {
     fun provideClinicRepository(
         reservationsRef: CollectionReference,
     ): ClinicRepository = ClinicRepositoryImpl(reservationsRef)
+
+    @Provides
+    fun provideUseCases(
+        repo: ClinicRepository,
+    ) = UseCases(
+        getReservations = GetReservations(repo)
+    )
 }

--- a/app/src/main/java/com/example/novadebug/domain/model/Response.kt
+++ b/app/src/main/java/com/example/novadebug/domain/model/Response.kt
@@ -1,0 +1,7 @@
+package com.example.novadebug.domain.model
+
+sealed class Response<out T> {
+    object Loading : Response<Nothing>()
+    data class Success<out T>(val data: T) : Response<T>()
+    data class Failure(val e: Exception) : Response<Nothing>()
+}

--- a/app/src/main/java/com/example/novadebug/domain/model/clinic/Doctor.kt
+++ b/app/src/main/java/com/example/novadebug/domain/model/clinic/Doctor.kt
@@ -1,0 +1,5 @@
+package com.example.novadebug.domain.model.clinic
+
+data class Doctor(
+    val id: String = ""
+)

--- a/app/src/main/java/com/example/novadebug/domain/model/clinic/Reservation.kt
+++ b/app/src/main/java/com/example/novadebug/domain/model/clinic/Reservation.kt
@@ -1,4 +1,4 @@
-package com.example.novadebug.domain.model.clinic.reservation
+package com.example.novadebug.domain.model.clinic
 
 import com.example.novadebug.domain.model.clinic.Doctor
 import com.google.firebase.Timestamp

--- a/app/src/main/java/com/example/novadebug/domain/model/clinic/User.kt
+++ b/app/src/main/java/com/example/novadebug/domain/model/clinic/User.kt
@@ -1,0 +1,5 @@
+package com.example.novadebug.domain.model.clinic
+
+data class User(
+    val id: String = ""
+)

--- a/app/src/main/java/com/example/novadebug/domain/model/clinic/reservation/Reservation.kt
+++ b/app/src/main/java/com/example/novadebug/domain/model/clinic/reservation/Reservation.kt
@@ -1,6 +1,6 @@
-package com.example.novadebug.model.clinic.reservation
+package com.example.novadebug.domain.model.clinic.reservation
 
-import com.example.novadebug.model.clinic.Doctor
+import com.example.novadebug.domain.model.clinic.Doctor
 import com.google.firebase.Timestamp
 
 data class Reservation(

--- a/app/src/main/java/com/example/novadebug/domain/repository/ClinicRepository.kt
+++ b/app/src/main/java/com/example/novadebug/domain/repository/ClinicRepository.kt
@@ -1,0 +1,13 @@
+package com.example.novadebug.domain.repository
+
+import com.example.novadebug.domain.model.Response
+import com.example.novadebug.domain.model.clinic.reservation.Reservation
+import kotlinx.coroutines.flow.Flow
+
+
+typealias Reservations = List<Reservation>
+typealias ReservationsResponse = Response<Reservations>
+
+interface ClinicRepository {
+    fun getReservations(): Flow<ReservationsResponse>
+}

--- a/app/src/main/java/com/example/novadebug/domain/repository/ClinicRepository.kt
+++ b/app/src/main/java/com/example/novadebug/domain/repository/ClinicRepository.kt
@@ -7,7 +7,10 @@ import kotlinx.coroutines.flow.Flow
 
 typealias Reservations = List<Reservation>
 typealias ReservationsResponse = Response<Reservations>
+typealias AddReservationResponse = Response<Boolean>
 
 interface ClinicRepository {
     fun getReservations(): Flow<ReservationsResponse>
+
+    suspend fun addReservation(reservation: Reservation): AddReservationResponse
 }

--- a/app/src/main/java/com/example/novadebug/domain/repository/ClinicRepository.kt
+++ b/app/src/main/java/com/example/novadebug/domain/repository/ClinicRepository.kt
@@ -1,7 +1,7 @@
 package com.example.novadebug.domain.repository
 
 import com.example.novadebug.domain.model.Response
-import com.example.novadebug.domain.model.clinic.reservation.Reservation
+import com.example.novadebug.domain.model.clinic.Reservation
 import kotlinx.coroutines.flow.Flow
 
 

--- a/app/src/main/java/com/example/novadebug/domain/use_case/AddReservation.kt
+++ b/app/src/main/java/com/example/novadebug/domain/use_case/AddReservation.kt
@@ -1,0 +1,8 @@
+package com.example.novadebug.domain.use_case
+
+import com.example.novadebug.domain.model.clinic.reservation.Reservation
+import com.example.novadebug.domain.repository.ClinicRepository
+
+class AddReservation(private val repo: ClinicRepository) {
+    suspend operator fun invoke(reservation: Reservation) = repo.addReservation(reservation)
+}

--- a/app/src/main/java/com/example/novadebug/domain/use_case/AddReservation.kt
+++ b/app/src/main/java/com/example/novadebug/domain/use_case/AddReservation.kt
@@ -1,6 +1,6 @@
 package com.example.novadebug.domain.use_case
 
-import com.example.novadebug.domain.model.clinic.reservation.Reservation
+import com.example.novadebug.domain.model.clinic.Reservation
 import com.example.novadebug.domain.repository.ClinicRepository
 
 class AddReservation(private val repo: ClinicRepository) {

--- a/app/src/main/java/com/example/novadebug/domain/use_case/GetReservations.kt
+++ b/app/src/main/java/com/example/novadebug/domain/use_case/GetReservations.kt
@@ -1,0 +1,7 @@
+package com.example.novadebug.domain.use_case
+
+import com.example.novadebug.domain.repository.ClinicRepository
+
+class GetReservations(private val repo: ClinicRepository) {
+    operator fun invoke() = repo.getReservations()
+}

--- a/app/src/main/java/com/example/novadebug/domain/use_case/UseCases.kt
+++ b/app/src/main/java/com/example/novadebug/domain/use_case/UseCases.kt
@@ -1,0 +1,5 @@
+package com.example.novadebug.domain.use_case
+
+data class UseCases(
+    val getReservations: GetReservations,
+)

--- a/app/src/main/java/com/example/novadebug/domain/use_case/UseCases.kt
+++ b/app/src/main/java/com/example/novadebug/domain/use_case/UseCases.kt
@@ -2,4 +2,5 @@ package com.example.novadebug.domain.use_case
 
 data class UseCases(
     val getReservations: GetReservations,
+    val addReservation: AddReservation
 )

--- a/app/src/main/java/com/example/novadebug/model/clinic/Doctor.kt
+++ b/app/src/main/java/com/example/novadebug/model/clinic/Doctor.kt
@@ -1,5 +1,0 @@
-package com.example.novadebug.model.clinic
-
-data class Doctor(
-    val id: String = ""
-)

--- a/app/src/main/java/com/example/novadebug/model/clinic/User.kt
+++ b/app/src/main/java/com/example/novadebug/model/clinic/User.kt
@@ -1,5 +1,0 @@
-package com.example.novadebug.model.clinic
-
-data class User(
-    val id: String = ""
-)

--- a/app/src/main/java/com/example/novadebug/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/novadebug/navigation/NavGraph.kt
@@ -5,7 +5,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.example.novadebug.screens.reservations.ReservationScreen
+import com.example.novadebug.presentation.reservations.ReservationScreen
 
 @Composable
 fun SetupNavGraph(navController: NavHostController) {

--- a/app/src/main/java/com/example/novadebug/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/novadebug/navigation/NavGraph.kt
@@ -11,7 +11,7 @@ import com.example.novadebug.presentation.reservations.ReservationScreen
 fun SetupNavGraph(navController: NavHostController) {
     NavHost(navController = navController, startDestination = Screen.Reservations.route) {
         composable(route = Screen.Reservations.route){
-            ReservationScreen(navController = navController)
+            ReservationScreen()
         }
     }
 }

--- a/app/src/main/java/com/example/novadebug/navigation/Screen.kt
+++ b/app/src/main/java/com/example/novadebug/navigation/Screen.kt
@@ -1,6 +1,6 @@
 package com.example.novadebug.navigation
 
-import com.example.novadebug.util.RESERVATIONS_SCREEN_ROUTE
+import com.example.novadebug.common.RESERVATIONS_SCREEN_ROUTE
 
 sealed class Screen(val route: String){
     object Reservations: Screen(route = RESERVATIONS_SCREEN_ROUTE)

--- a/app/src/main/java/com/example/novadebug/presentation/MainActivity.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.novadebug
+package com.example.novadebug.presentation
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsScreen.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsScreen.kt
@@ -3,13 +3,32 @@ package com.example.novadebug.presentation.reservations
 
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.novadebug.common.components.TopBar
+import com.example.novadebug.domain.model.clinic.Doctor
+import com.example.novadebug.domain.model.clinic.reservation.Reservation
+import com.example.novadebug.presentation.reservations.components.AddReservation
+import com.example.novadebug.presentation.reservations.components.AddReservationFab
 import com.example.novadebug.presentation.reservations.components.ReservationContent
 import com.example.novadebug.presentation.reservations.components.Reservations
+import com.google.firebase.Timestamp
 
+var dummyReservation = Reservation(
+    id = "",
+    area = arrayListOf("area 1", "area 2"),
+    branch = "roshdi",
+    device = "candela",
+    doctor = Doctor(id = "22222"),
+    status = "scheduled",
+    time = Timestamp.now(),
+    userId = "44444",
+    expectedDuration = 30
+)
 
 @Composable
-fun ReservationScreen() {
+fun ReservationScreen(
+    viewModel: ReservationsViewModel = hiltViewModel(),
+) {
     Scaffold(
         topBar = { TopBar() },
         content = { padding ->
@@ -22,7 +41,13 @@ fun ReservationScreen() {
                 }
             )
 
+        },
+        floatingActionButton = {
+            AddReservationFab(
+                addReservation = { viewModel.addReservation(dummyReservation) }
+            )
         }
     )
+    AddReservation()
 }
 

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsScreen.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsScreen.kt
@@ -1,4 +1,4 @@
-package com.example.novadebug.screens.reservations
+package com.example.novadebug.presentation.reservations
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsScreen.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.novadebug.common.components.TopBar
 import com.example.novadebug.domain.model.clinic.Doctor
-import com.example.novadebug.domain.model.clinic.reservation.Reservation
+import com.example.novadebug.domain.model.clinic.Reservation
 import com.example.novadebug.presentation.reservations.components.AddReservation
 import com.example.novadebug.presentation.reservations.components.AddReservationFab
 import com.example.novadebug.presentation.reservations.components.ReservationContent
@@ -20,9 +20,9 @@ var dummyReservation = Reservation(
     device = "candela",
     doctor = Doctor(id = "22222"),
     status = "scheduled",
-    time = Timestamp.now(),
+    dateTime = Timestamp.now(),
     userId = "44444",
-    expectedDuration = 30
+    expectedDurationMin = 30
 )
 
 @Composable

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsScreen.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsScreen.kt
@@ -1,167 +1,28 @@
 package com.example.novadebug.presentation.reservations
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
+
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
-import com.example.novadebug.domain.model.clinic.Doctor
-import com.example.novadebug.domain.model.clinic.reservation.Reservation
-import com.google.firebase.Timestamp
+import com.example.novadebug.common.components.TopBar
+import com.example.novadebug.presentation.reservations.components.ReservationContent
+import com.example.novadebug.presentation.reservations.components.Reservations
 
 
 @Composable
-fun ReservationScreen(
-    reservationsViewModel: ReservationsViewModel = hiltViewModel(),
-    navController: NavHostController,
-) {
-    // Todo : is this the right value for the key? "true" will make this block execute only once.
-    LaunchedEffect(key1 = true) {
-        reservationsViewModel.updateReservations()
-    }
-
-    val reservations = reservationsViewModel.reservations
-    val isLoading = reservationsViewModel.loading
-
+fun ReservationScreen() {
     Scaffold(
-        topBar = { TopAppBar(title = { Text(text = "Nova Clinic") }) },
-        content = {
-            ReservationScreenContent(reservations, isLoading.value)
-        }
-    )
-}
-
-@Composable
-fun ReservationScreenContent(items: List<Reservation>, isLoading: Boolean) {
-    if (isLoading) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(text = "Loading")
-        }
-    } else {
-        ReservationList(items = items)
-    }
-
-}
-
-@Composable
-fun ReservationList(items: List<Reservation>) {
-    LazyColumn(
-        modifier = Modifier
-            .padding(16.dp)
-            .fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        items(items = items) { item ->
-            ReservationCardItem(reservation = item)
-        }
-    }
-}
-
-@Composable
-fun ReservationCardItem(reservation: Reservation) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(150.dp),
-        elevation = 10.dp,
-        shape = RoundedCornerShape(16.dp),
-    ) {
-        Row(modifier = Modifier.fillMaxHeight()) {
-            Image(
-                painter = painterResource(com.example.novadebug.R.drawable.man),
-                contentDescription = "Round corner image",
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .padding(10.dp)
-                    .weight(1f)
-                    .fillMaxHeight()
-                    .clip(RoundedCornerShape(10))
-            )
-            Column(
-                Modifier
-                    .padding(16.dp)
-                    .fillMaxHeight()
-                    .weight(2f), verticalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(text = reservation.id, style = MaterialTheme.typography.subtitle1)
-
-                Row(
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text(text = reservation.branch)
-                    Text(text = reservation.device)
+        topBar = { TopBar() },
+        content = { padding ->
+            Reservations(
+                reservationContent = { reservations ->
+                    ReservationContent(
+                        padding = padding,
+                        reservations = reservations
+                    )
                 }
+            )
 
-            }
         }
-    }
-}
-
-@Preview
-@Composable
-fun ReservationListPreview() {
-    val reservation = Reservation(
-        id = "1FRFZpSa7fWPlsaYJc7E",
-        area = arrayListOf(
-            "area1",
-            "area2"
-        ),
-        branch = "smoha",
-        device = "candela",
-        doctor = Doctor(
-            id = "RfCDM6o8knwSElvVhK33"
-        ),
-        status = "scheduled",
-        time = Timestamp.now(),
-        userId = "o2SG28pYMx8TgicYdTlu",
-        expectedDuration = 30
-    )
-    val reservationsList = listOf(
-        reservation,
-        reservation.copy(status = "canceled"),
-        reservation.copy(expectedDuration = 15),
-        reservation.copy(status = "canceled")
-    )
-    ReservationList(
-        reservationsList
     )
 }
 
-@Preview
-@Composable
-fun ReservationCardItemPreview() {
-    ReservationCardItem(
-        reservation = Reservation(
-            id = "1FRFZpSa7fWPlsaYJc7E",
-            area = arrayListOf(
-                "area1",
-                "area2"
-            ),
-            branch = "smoha",
-            device = "candela",
-            doctor = Doctor(
-                id = "RfCDM6o8knwSElvVhK33"
-            ),
-            status = "scheduled",
-            time = Timestamp.now(),
-            userId = "o2SG28pYMx8TgicYdTlu",
-            expectedDuration = 30
-        )
-    )
-}

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsScreen.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsScreen.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
-import com.example.novadebug.model.clinic.Doctor
-import com.example.novadebug.model.clinic.reservation.Reservation
+import com.example.novadebug.domain.model.clinic.Doctor
+import com.example.novadebug.domain.model.clinic.reservation.Reservation
 import com.google.firebase.Timestamp
 
 

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
@@ -1,15 +1,14 @@
 package com.example.novadebug.presentation.reservations
 
-import android.nfc.Tag
 import android.util.Log
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.novadebug.model.clinic.reservation.Reservation
-import com.example.novadebug.util.CLIENTS_COLLECTION
-import com.example.novadebug.util.CLIENT_NAME
-import com.example.novadebug.util.CLIENT_RESERVATIONS
+import com.example.novadebug.common.CLIENTS_COLLECTION
+import com.example.novadebug.common.CLIENT_NAME
+import com.example.novadebug.common.CLIENT_RESERVATIONS
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.firestore.ktx.toObject
 import com.google.firebase.ktx.Firebase

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.novadebug.screens.reservations
+package com.example.novadebug.presentation.reservations
 
 import android.nfc.Tag
 import android.util.Log

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.getValue
-import com.example.novadebug.domain.model.clinic.reservation.Reservation
+import com.example.novadebug.domain.model.clinic.Reservation
 import com.example.novadebug.domain.repository.AddReservationResponse
 
 

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.novadebug.model.clinic.reservation.Reservation
+import com.example.novadebug.domain.model.clinic.reservation.Reservation
 import com.example.novadebug.common.CLIENTS_COLLECTION
 import com.example.novadebug.common.CLIENT_NAME
 import com.example.novadebug.common.CLIENT_RESERVATIONS

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
@@ -1,63 +1,50 @@
 package com.example.novadebug.presentation.reservations
 
-import android.util.Log
-import androidx.compose.runtime.mutableStateListOf
+
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.novadebug.domain.model.clinic.reservation.Reservation
-import com.example.novadebug.common.CLIENTS_COLLECTION
-import com.example.novadebug.common.CLIENT_NAME
-import com.example.novadebug.common.CLIENT_RESERVATIONS
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.firestore.ktx.toObject
-import com.google.firebase.ktx.Firebase
+import com.example.novadebug.domain.model.Response.*
+import com.example.novadebug.domain.repository.ReservationsResponse
+import com.example.novadebug.domain.use_case.UseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
+
 
 private const val TAG = "ReservationsViewModel"
 
 @HiltViewModel
-class ReservationsViewModel @Inject constructor() : ViewModel() {
-    val reservations = mutableStateListOf<Reservation>()
-    private val reservationRef by lazy {
-        db.collection(CLIENTS_COLLECTION).document(CLIENT_NAME).collection(CLIENT_RESERVATIONS)
+class ReservationsViewModel @Inject constructor(
+    private val useCases: UseCases,
+) : ViewModel() {
+    var reservationsResponse by mutableStateOf<ReservationsResponse>(Loading)
+        private set
 
-    }
-    private val db = Firebase.firestore
 
-    //TODO can be replaced by State Sealed Class, use Result Class also
-    val loading = mutableStateOf(false)
-
-    fun updateReservations() {
-        loading.value = true
-        reservationRef
-            .get()
-            .addOnSuccessListener { documents ->
-                for (document in documents) {
-                    Log.d(TAG, "reservationsViewModel: ${document.id} --> ${document.data}")
-                    val reservation = document.toObject<Reservation>()
-                    Log.d(TAG, "reservationsViewModel: ${reservation.id}")
-                    Log.d(TAG, "data: ${reservation.time.toDate()}")
-                    reservations.add(reservation)
-                    loading.value = false
-                }
-            }.addOnFailureListener {
-                Log.d(TAG, "reservationsViewModel: Failed to retrieve data")
-                loading.value = false
-            }
+    init {
+        getReservations()
     }
 
-    fun addNewReservation(reservation: Reservation) {
-        viewModelScope.launch {
-            reservationRef.add(reservation)
-                .addOnSuccessListener {
-                    Log.d(TAG, "Added Document Successfully with ID : ${it.id}")
-                }
-                .addOnFailureListener {
-                    Log.e(TAG, "Failed to Add Document", it.cause)
-                }
+    private fun getReservations() = viewModelScope.launch {
+        useCases.getReservations().collect { response ->
+            reservationsResponse = response
         }
     }
+
+
+//
+//    fun addNewReservation(reservation: Reservation) {
+//        viewModelScope.launch {
+//            reservationRef.add(reservation)
+//                .addOnSuccessListener {
+//                    Log.d(TAG, "Added Document Successfully with ID : ${it.id}")
+//                }
+//                .addOnFailureListener {
+//                    Log.e(TAG, "Failed to Add Document", it.cause)
+//                }
+//        }
+//    }
 }

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/ReservationsViewModel.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.getValue
+import com.example.novadebug.domain.model.clinic.reservation.Reservation
+import com.example.novadebug.domain.repository.AddReservationResponse
 
 
 private const val TAG = "ReservationsViewModel"
@@ -22,7 +24,7 @@ class ReservationsViewModel @Inject constructor(
 ) : ViewModel() {
     var reservationsResponse by mutableStateOf<ReservationsResponse>(Loading)
         private set
-
+    var addReservationResponse by mutableStateOf<AddReservationResponse>(Success(false))
 
     init {
         getReservations()
@@ -34,17 +36,9 @@ class ReservationsViewModel @Inject constructor(
         }
     }
 
+    fun addReservation(reservation: Reservation) = viewModelScope.launch {
+        addReservationResponse = Loading
+        addReservationResponse = useCases.addReservation(reservation)
+    }
 
-//
-//    fun addNewReservation(reservation: Reservation) {
-//        viewModelScope.launch {
-//            reservationRef.add(reservation)
-//                .addOnSuccessListener {
-//                    Log.d(TAG, "Added Document Successfully with ID : ${it.id}")
-//                }
-//                .addOnFailureListener {
-//                    Log.e(TAG, "Failed to Add Document", it.cause)
-//                }
-//        }
-//    }
 }

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/components/AddReservation.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/components/AddReservation.kt
@@ -1,0 +1,22 @@
+package com.example.novadebug.presentation.reservations.components
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.novadebug.common.components.ProgressBar
+import com.example.novadebug.domain.model.Response.*
+import com.example.novadebug.presentation.reservations.ReservationsViewModel
+
+@Composable
+fun AddReservation(
+    viewModel: ReservationsViewModel = hiltViewModel(),
+) {
+    when (val addReservationResponse = viewModel.addReservationResponse) {
+        is Loading -> ProgressBar()
+
+        is Success,
+        -> Unit
+
+        is Failure,
+        -> print(addReservationResponse.e)
+    }
+}

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/components/AddReservationFAB.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/components/AddReservationFAB.kt
@@ -1,0 +1,25 @@
+package com.example.novadebug.presentation.reservations.components
+
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.example.novadebug.R
+
+@Composable
+fun AddReservationFab(
+    addReservation: () -> Unit,
+) {
+    FloatingActionButton(
+        onClick = addReservation,
+        backgroundColor = MaterialTheme.colors.primary
+    ) {
+        Icon(
+            imageVector = Icons.Default.Add,
+            contentDescription = stringResource(id = R.string.add_reservation)
+        )
+    }
+}

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/components/ReservationCard.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/components/ReservationCard.kt
@@ -20,7 +20,9 @@ fun ReservationCard(reservation: Reservation) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .height(150.dp),
+            .height(150.dp)
+            .padding(top = 16.dp)
+        ,
         elevation = 10.dp,
         shape = RoundedCornerShape(16.dp),
     ) {

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/components/ReservationCard.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/components/ReservationCard.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.example.novadebug.R
-import com.example.novadebug.domain.model.clinic.reservation.Reservation
+import com.example.novadebug.domain.model.clinic.Reservation
 
 @Composable
 fun ReservationCard(reservation: Reservation) {

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/components/ReservationCard.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/components/ReservationCard.kt
@@ -1,0 +1,57 @@
+package com.example.novadebug.presentation.reservations.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.example.novadebug.R
+import com.example.novadebug.domain.model.clinic.reservation.Reservation
+
+@Composable
+fun ReservationCard(reservation: Reservation) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(150.dp),
+        elevation = 10.dp,
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Row(modifier = Modifier.fillMaxHeight()) {
+            Image(
+                painter = painterResource(R.drawable.man),
+                contentDescription = "Round corner image",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .padding(10.dp)
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(10))
+            )
+            Column(
+                Modifier
+                    .padding(16.dp)
+                    .fillMaxHeight()
+                    .weight(2f), verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(text = reservation.id, style = MaterialTheme.typography.subtitle1)
+
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(text = reservation.branch)
+                    Text(text = reservation.device)
+                }
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/components/ReservationContent.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/components/ReservationContent.kt
@@ -1,0 +1,24 @@
+package com.example.novadebug.presentation.reservations.components
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.example.novadebug.domain.repository.Reservations
+
+@Composable
+fun ReservationContent(
+    padding: PaddingValues,
+    reservations: Reservations,
+) {
+    LazyColumn(modifier = Modifier
+        .fillMaxSize()
+        .padding(padding)) {
+        items(reservations) { reservation ->
+            ReservationCard(reservation)
+        }
+    }
+}

--- a/app/src/main/java/com/example/novadebug/presentation/reservations/components/Reservations.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/reservations/components/Reservations.kt
@@ -1,0 +1,21 @@
+package com.example.novadebug.presentation.reservations.components
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.novadebug.common.components.ProgressBar
+import com.example.novadebug.domain.model.Response.*
+import com.example.novadebug.domain.repository.Reservations
+import com.example.novadebug.presentation.reservations.ReservationsViewModel
+
+@Composable
+fun Reservations(
+    viewModel: ReservationsViewModel = hiltViewModel(),
+    reservationContent: @Composable (reservations: Reservations) -> Unit,
+) {
+    when (val reservationsResponse = viewModel.reservationsResponse) {
+        is Loading -> ProgressBar()
+        is Success -> reservationContent(reservationsResponse.data)
+        is Failure -> print(reservationsResponse.e)
+    }
+
+}

--- a/app/src/main/java/com/example/novadebug/presentation/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.example.novadebug.ui.theme
+package com.example.novadebug.presentation.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/example/novadebug/presentation/ui/theme/Shape.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/ui/theme/Shape.kt
@@ -1,4 +1,4 @@
-package com.example.novadebug.ui.theme
+package com.example.novadebug.presentation.ui.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Shapes

--- a/app/src/main/java/com/example/novadebug/presentation/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.example.novadebug.ui.theme
+package com.example.novadebug.presentation.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme

--- a/app/src/main/java/com/example/novadebug/presentation/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/novadebug/presentation/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.example.novadebug.ui.theme
+package com.example.novadebug.presentation.ui.theme
 
 import androidx.compose.material.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Nova Debug</string>
+    <string name="add_reservation">Add Reservation</string>
 </resources>


### PR DESCRIPTION
The app supports only 2 features until now:

view all reservatios (barnch and device fields only)
add new reservation (dummy reservation. the user can not insert reservation details yet)
Added the following packages

presentation
** contains ui package, components and view models

domain
** contains models, repo interface, and use cases

data
** contains repo impl

di
** contains App module to provide the dependecies needed accross the application

common
** contains constants and components used in common between all layers